### PR TITLE
Fixes React Guide link.

### DIFF
--- a/docs/installation/module.md
+++ b/docs/installation/module.md
@@ -31,4 +31,4 @@ ReactDOM.render(
 );
 ```
 
-See the [React API](/api/react) guide for more details.
+See the [React API](/guides/react) guide for more details.


### PR DESCRIPTION
The react guide link in the installation page points to a page that no longer exists. This fixes it by pointing at the correct path. 